### PR TITLE
Remove import scrollToTop

### DIFF
--- a/src/pages/Detail.js
+++ b/src/pages/Detail.js
@@ -3,7 +3,6 @@ import { useParams } from 'react-router-dom';
 
 import { detail } from '../api';
 import useFetch from '../hooks/UseFetch';
-import { scrollToTop } from '../utils';
 import Context from '../state/Context';
 import Comic from '../layout/components/Comic';
 import Pagination from '../layout/components/Pagination';


### PR DESCRIPTION
Fix : Line 6:10:  'scrollToTop' is defined but never used in src/pages/Detail.js